### PR TITLE
Update date-picker.html

### DIFF
--- a/date-picker.html
+++ b/date-picker.html
@@ -160,7 +160,7 @@ $(function(){
 													<button type="button" aria-label="calendar_schedular_unavailable, Saturday December 26 2020" aria-pressed="false" class="Calendar-item Calendar-item--unavailable" data-timestamp="1608955200" data-day="26" data-date="2020-12-26" tabindex="-1">26</button>
 												</div>
 												<div class="Calendar-row">
-													<button type="button" aria-label="calendar_schedular_unavailable, Sunday December 27 2020" aria-pressed="false" class="Calendar-item Calendar-item--unavailable" data-timestamp="1609041600" data-day="27" data-date="2020-12-27"tabindex="-1">27</button>
+													<button type="button" aria-label="calendar_schedular_unavailable, Sunday December 27 2020" aria-pressed="false" class="Calendar-item Calendar-item--unavailable" data-timestamp="1609041600" data-day="27" data-date="2020-12-27" tabindex="-1">27</button>
 													<button type="button" aria-label="Monday December 28 2020" aria-pressed="false" class="Calendar-item Calendar-item--active" data-timestamp="1609128000" data-day="28" data-date="2020-12-28">28</button>
 													<button type="button" aria-label="Tuesday December 29 2020" aria-pressed="false" class="Calendar-item Calendar-item--active" data-timestamp="1609214400" data-day="29" data-date="2020-12-29">29</button>
 													<button type="button" aria-label="Wednesday December 30 2020" aria-pressed="false" class="Calendar-item Calendar-item--active" data-timestamp="1609300800" data-day="30" data-date="2020-12-30">30</button>
@@ -172,9 +172,165 @@ $(function(){
 									</section>
 								</div>
 							</div><!-- / example col -->
-						</section><!--/row-->
+						</section><!--/row -->
+						
+						
+																
+						<!-- French date picker example -->
 						<section class="row">
-										
+							<div class="col-md-12 col-xs-12">
+								<h2>Date picker example (<span lang="fr">en français</span>)</h2>
+								<div class="exampleDisplay">
+
+									
+
+
+									<section class="Calendar" aria-label="Calendrier"><!-- Update the aria-label from "Calendar" to "Calendrier" -->
+										<section aria-label="Navigation du calendrier" class="Calendar-nav"><!-- Update the aria-label from "Calendar Navaigation" to "Navigation du calendrier" -->
+											<button id="previous" class="Calendar-nav--button Calendar-nav--button--unavailable" type="button" aria-label="le mois précédent" tabindex="-1">❮</button><!-- Update the aria-label from "Previous month" to "le mois précédent" -->
+											<div class="Nav--month">décembre</div><!-- Update from "December" to "le mois précédent" -->
+											<!-- 
+												List of the months in French 
+												*******Note that they are always in lower case*******
+													janvier
+													février
+													mars
+													avril
+													mai
+													juin
+													juillet
+													août
+													septembre
+													octobre
+													novembre
+													décembre
+
+
+	
+												List of abbreviated months in French
+												*******Note that they are always in lower case and period 
+	`													(exceptation for period are: mars, mai, juin and août *******
+													janv.
+													févr.
+													mars
+													avr.
+													mai
+													juin
+													juill.
+													août
+													sept.
+													oct.
+													nov.
+													déc.
+
+												-->
+
+											
+											
+											<button id="next" class="Calendar-nav--button" type="button" aria-label="le mois suivant">❯</button><!-- Update the aria-label from "Next month" to "le mois suivant" -->
+										</section>
+										<div class="Calendar-grid">
+											<div class="Calendar-days Calendar-row" aria-disabled="true" role="presentation" aria-hidden="true">
+												<span class="Calendar-item Calendar-item--day" aria-label="	dimanche">dim.</span>
+												<span class="Calendar-item Calendar-item--day" aria-label="	lundi">lun.</span>
+												<span class="Calendar-item Calendar-item--day" aria-label="	mardi">mar.</span>
+												<span class="Calendar-item Calendar-item--day" aria-label="	mercredi">mer.</span>
+												<span class="Calendar-item Calendar-item--day" aria-label="	jeudi">jeu.</span>
+												<span class="Calendar-item Calendar-item--day" aria-label="	vendredi">ven.</span>
+												<span class="Calendar-item Calendar-item--day" aria-label="	samedi">sam.</span>
+											</div>
+											
+											<!-- 
+												List of the months in French 
+												*******Note that they are always in lower case*******
+													dimanche
+													lundi
+													mardi
+													mercredi
+													jeudi
+													vendredi
+													samedi
+
+	
+												List of abbreviated months in French
+												*******Note that they are always in lower case and period  *******
+													dim.
+													lun.
+													mar.
+													mer.
+													jeu.
+													ven.
+													sam.
+
+												-->											
+
+											
+					
+
+											<section id="Calendar-dates" aria-label="Dates du calendrier" role="application"><!-- Update the aria-label from "Calendar dates" to "le mois suivant" -->
+										</section>
+											
+											
+											
+											<!-- 
+												Written dates in French should be all in lower case (day and month) 
+													English:
+														Tuesday December 01 2020
+													French:
+														mardi 01 décembre 2021
+ 												-->
+											
+												<div class="Calendar-row">
+													<span class="Calendar-item Calendar-item--empty"></span>
+													<span class="Calendar-item Calendar-item--empty"></span>
+													<button type="button" aria-label="calendar_schedular_unavailable, mardi 01 décembre 2021" aria-pressed="false" class="Calendar-item Calendar-item--unavailable" data-timestamp="1606795200" data-day="1" data-date="2020-12-01" tabindex="-1">1</button>
+													<button type="button" aria-label="calendar_schedular_unavailable, mercredi 02 décembre  2020" aria-pressed="false" class="Calendar-item Calendar-item--unavailable" data-timestamp="1606881600" data-day="2" data-date="2020-12-02" tabindex="-1">2</button>
+													<button type="button" aria-label="calendar_schedular_unavailable, jeudi 03 décembre 2020" aria-pressed="false" class="Calendar-item Calendar-item--unavailable" data-timestamp="1606968000" data-day="3" data-date="2020-12-03" tabindex="-1">3</button>
+													<button type="button" aria-label="calendar_schedular_unavailable, vendredi 04 décembre 2020" aria-pressed="false" class="Calendar-item Calendar-item--unavailable" data-timestamp="1607054400" data-day="4" data-date="2020-12-04" tabindex="-1">4</button>
+													<button type="button" aria-label="calendar_schedular_unavailable, samedi 05 décembre 2020" aria-pressed="false" class="Calendar-item Calendar-item--unavailable" data-timestamp="1607140800" data-day="5" data-date="2020-12-05" tabindex="-1">5</button>
+												</div>
+												<div class="Calendar-row">
+													<button type="button" aria-label="calendar_schedular_unavailable, dimanche 06 décembre 2020" aria-pressed="false" class="Calendar-item Calendar-item--unavailable" data-timestamp="1607227200" data-day="6" data-date="2020-12-06" tabindex="-1">6</button>
+													<button type="button" aria-label="calendar_schedular_unavailable, lundi 07 décembre 2020" aria-pressed="false" class="Calendar-item Calendar-item--unavailable" data-timestamp="1607313600" data-day="7" data-date="2020-12-07" tabindex="-1">7</button>
+													<button type="button" aria-label="calendar_schedular_unavailable, mardi 08 décembre 2020" aria-pressed="false" class="Calendar-item Calendar-item--unavailable" data-timestamp="1607400000" data-day="8" data-date="2020-12-08" tabindex="-1">8</button>
+													<button type="button" aria-label="calendar_schedular_unavailable, mercredi 09 décembre 2020" aria-pressed="false" class="Calendar-item Calendar-item--unavailable" data-timestamp="1607486400" data-day="9" data-date="2020-12-09" tabindex="-1">9</button>
+													<button type="button" aria-label="calendar_schedular_unavailable, jeudi 10 décembre 2020" aria-pressed="false" class="Calendar-item Calendar-item--unavailable" data-timestamp="1607572800" data-day="10" data-date="2020-12-10" tabindex="-1">10</button>
+													<button type="button" aria-label="calendar_schedular_unavailable, vendredi 11 décembre 2020" aria-pressed="false" class="Calendar-item Calendar-item--unavailable" data-timestamp="1607659200" data-day="11" data-date="2020-12-11" tabindex="-1">11</button>
+													<button type="button" aria-label="calendar_schedular_unavailable, samedi 12 décembre 2020" aria-pressed="false" class="Calendar-item Calendar-item--unavailable" data-timestamp="1607745600" data-day="12" data-date="2020-12-12" tabindex="-1">12</button>
+												</div>
+												<div class="Calendar-row">
+													<button type="button" aria-label="calendar_schedular_unavailable, dimanche 13 décembre 2020" aria-pressed="false" class="Calendar-item Calendar-item--unavailable" data-timestamp="1607832000" data-day="13" data-date="2020-12-13" tabindex="-1">13</button>
+													<button type="button" aria-label="calendar_schedular_unavailable, lundi 14 décembre 2020" aria-pressed="false" class="Calendar-item Calendar-item--unavailable" data-timestamp="1607918400" data-day="14" data-date="2020-12-14" tabindex="-1">14</button>
+													<button type="button" aria-label="calendar_schedular_unavailable, mardi 15 décembre 2020" aria-pressed="false" class="Calendar-item Calendar-item--unavailable" data-timestamp="1608004800" data-day="15" data-date="2020-12-15" aria-current="date" tabindex="-1">15</button>
+													<button type="button" aria-label="mercredi 16 décembre 2020" aria-pressed="true" class="Calendar-item Calendar-item--active" data-timestamp="1608091200" data-day="16" data-date="2020-12-16">16</button>
+													<button type="button" aria-label="jeudi 17 décembre 2020" aria-pressed="false" class="Calendar-item Calendar-item--active" data-timestamp="1608177600" data-day="17" data-date="2020-12-17">17</button>
+													<button type="button" aria-label="vendredi 18 décembre 2020" aria-pressed="false" class="Calendar-item Calendar-item--active" data-timestamp="1608264000" data-day="18" data-date="2020-12-18">18</button>
+													<button type="button" aria-label="calendar_schedular_unavailable, samedi 19 décembre 2020" aria-pressed="false" class="Calendar-item Calendar-item--unavailable" data-timestamp="1608350400" data-day="19" data-date="2020-12-19" tabindex="-1">19</button>
+												</div>
+												<div class="Calendar-row">
+													<button type="button" aria-label="calendar_schedular_unavailable, dimanche 20 décembre 2020" aria-pressed="false" class="Calendar-item Calendar-item--unavailable" data-timestamp="1608436800" data-day="20" data-date="2020-12-20" tabindex="-1">20</button>
+													<button type="button" aria-label="lundi 21 décembre 2020" aria-pressed="false" class="Calendar-item Calendar-item--active" data-timestamp="1608523200" data-day="21" data-date="2020-12-21">21</button>
+													<button type="button" aria-label="mardi 22 décembre 2020" aria-pressed="false" class="Calendar-item Calendar-item--active" data-timestamp="1608609600" data-day="22" data-date="2020-12-22">22</button>
+													<button type="button" aria-label="mercredi 23 décembre 2020" aria-pressed="false" class="Calendar-item Calendar-item--active" data-timestamp="1608696000" data-day="23" data-date="2020-12-23">23</button>
+													<button type="button" aria-label="jeudi 24 décembre 2020" aria-pressed="false" class="Calendar-item Calendar-item--active" data-timestamp="1608782400" data-day="24" data-date="2020-12-24">24</button>
+													<button type="button" aria-label="vendredi 25 décembre 2020" aria-pressed="false" class="Calendar-item Calendar-item--active" data-timestamp="1608868800" data-day="25" data-date="2020-12-25">25</button>
+													<button type="button" aria-label="calendar_schedular_unavailable, samedi 26 décembre 2020" aria-pressed="false" class="Calendar-item Calendar-item--unavailable" data-timestamp="1608955200" data-day="26" data-date="2020-12-26" tabindex="-1">26</button>
+												</div>
+												<div class="Calendar-row">
+													<button type="button" aria-label="calendar_schedular_unavailable, dimanche 27 décembre 2020" aria-pressed="false" class="Calendar-item Calendar-item--unavailable" data-timestamp="1609041600" data-day="27" data-date="2020-12-27" tabindex="-1">27</button>
+													<button type="button" aria-label="lundi 28 décembre 2020" aria-pressed="false" class="Calendar-item Calendar-item--active" data-timestamp="1609128000" data-day="28" data-date="2020-12-28">28</button>
+													<button type="button" aria-label="mardi 29 décembre 2020" aria-pressed="false" class="Calendar-item Calendar-item--active" data-timestamp="1609214400" data-day="29" data-date="2020-12-29">29</button>
+													<button type="button" aria-label="mercredi 30 décembre 2020" aria-pressed="false" class="Calendar-item Calendar-item--active" data-timestamp="1609300800" data-day="30" data-date="2020-12-30">30</button>
+													<button type="button" aria-label="jeudi 31 décembre 2020" aria-pressed="false" class="Calendar-item Calendar-item--active" data-timestamp="1609387200" data-day="31" data-date="2020-12-31">31</button>
+													<span class="Calendar-item Calendar-item--empty"></span><span class="Calendar-item Calendar-item--empty"></span>
+												</div>
+
+										</div>
+											</section>							
+
+								</div>
+							</div>
+						</section>
 
 
 					</div><!-- /col-xs-8 -->


### PR DESCRIPTION
Added a French example of Date Picker.

There was error in the English code.
Missing space on line 163
data-date="2020-12-27"tabindex="-1"

Also, a tag div tag (that inside a section tag) was  closed outside of the section tag.

@connorscarolyns you might want to clean up the English. The French has comments around what I changed. For example,

Update the aria-label from "Previous month" to "le mois précédent"